### PR TITLE
Update deployment workflows to compile and deploy standalone HTML

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -15,13 +15,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      
+      - name: Compile standalone HTML
+        run: |
+          python compile.py
+          mv bip39-standalone.html index.html
+          mkdir -p dist
+          mv index.html dist/
+      
       - name: Deploy to All-Inkl Development Server
         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
           server: ${{ secrets.DEV_HOST }}
           username: ${{ secrets.DEV_USER }}
           password: ${{ secrets.DEV_PASSWORD }}
-          local-dir: ./src/
+          local-dir: ./dist/
           server-dir: ./
           protocol: ftps
           port: 21

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -15,13 +15,25 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      
+      - name: Compile standalone HTML
+        run: |
+          python compile.py
+          mv bip39-standalone.html index.html
+          mkdir -p dist
+          mv index.html dist/
+      
       - name: Deploy to All-Inkl Production Server
         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
           server: ${{ secrets.PRD_HOST }}
           username: ${{ secrets.PRD_USER }}
           password: ${{ secrets.PRD_PASSWORD }}
-          local-dir: ./src/
+          local-dir: ./dist/
           server-dir: ./
           protocol: ftps
           port: 21


### PR DESCRIPTION
- Add Python setup step to both dev and production workflows
- Compile bip39-standalone.html using compile.py
- Rename compiled file to index.html
- Deploy only the compiled standalone file instead of source files
- This ensures all JavaScript and CSS are embedded in a single file